### PR TITLE
Remove a debug print that caused a crash

### DIFF
--- a/amuse-interface/interface.cc
+++ b/amuse-interface/interface.cc
@@ -66,9 +66,9 @@ extern "C" {
 #endif
         delete ptr;
         ptr=NULL;
-#ifdef INTERFACE_DEBUG_PRINT
-        if(ptr->my_rank==0) std::cout<<"PETAR: cleanup_code end\n";
-#endif
+//#ifdef INTERFACE_DEBUG_PRINT
+//        if(ptr->my_rank==0) std::cout<<"PETAR: cleanup_code end\n";
+//#endif
         return 0;
     }
 


### PR DESCRIPTION
since ptr was just set to NULL before, this could never be successful and would crash PeTar.