### PR TITLE
fixed issue with masses after pair instability supernovae

### DIFF
--- a/bse-interface/mobse/evolv1.f
+++ b/bse-interface/mobse/evolv1.f
@@ -60,9 +60,12 @@ c-------------------------------------------------------------c
       REAL*8 pts1,pts2,pts3
       COMMON /POINTS/ pts1,pts2,pts3
       real*8 ffb,mfin
+      real*8 zero
       integer ECS
 *     for kick, arguments must be variables
       real*8 m2,ecc,sep,jorb
+
+      zero = 0.d0
       m2 = 0.d0
       ecc= 0.d0
       sep= -1.d0
@@ -84,6 +87,24 @@ c-------------------------------------------------------------c
       endif
       k2 = 0.15d0
       rflag = 0
+
+*
+*     MM added following lines 2021/09/27
+*     to zero masses and other dangerous quantities if stellar type is 15
+*
+
+      if(kw.eq.15)then
+         mass=zero
+         mt=zero
+         r=1.0d-10
+         lum=1.0e-10
+         mc=zero
+         rc=1.0d-10
+         menv=zero
+         renv=1.0d-10
+         mfin=zero
+      endif
+      
 *
 * Setup variables which control the output (if it is required).
 *
@@ -381,6 +402,22 @@ c-------------------------------------------------------------c
 *
  90   continue
 *
+*     MM added following lines 2021/09/27
+*     to zero masses and other dangerous quantities of stars 15
+*
+
+      if(kw.eq.15)then
+         mass=zero
+         mt=zero
+         r=1.0d-10
+         lum=1.0e-10
+         mc=zero
+         rc=1.0d-10
+         menv=zero
+         renv=1.0d-10
+         mfin=zero
+      endif
+
       if (j.eq.nv) then
          write(*,*) 'MOSSE Warning, too many iteration loop >',nv,
      &        ' time_now=',tphys,' time_end=',tphysf,' mass=',mt,

--- a/bse-interface/mobse/evolv2.f
+++ b/bse-interface/mobse/evolv2.f
@@ -247,8 +247,38 @@ c      COMMON /BINARY/ bcm,bpp
       ngtv = -1.d0
       ngtv2 = -2.d0
       twopi = 2.d0*ACOS(-1.d0)
+
 *
-* Initialize the parameters.
+*     MM added following lines on 2021/09/26
+*     to zero masses and other dangerous quantities if stellar type is 15
+*
+      if(kstar(1).eq.15)then
+         mass0(1)=zero
+         mass(1)=zero
+         rad(1)=1.0d-10
+         lumin(1)=1.0e-10
+         massc(1)=zero
+         radc(1)=1.0d-10
+         menv(1)=zero
+         renv(1)=1.0d-10
+         ospin(1)=zero
+      endif
+      if(kstar(2).eq.15)then
+         mass0(2)=zero
+         mass(2)=zero
+         rad(2)=1.0d-10
+         lumin(2)=1.0e-10
+         massc(2)=zero
+         radc(2)=1.0d-10
+         menv(2)=zero
+         renv(2)=1.0d-10
+         ospin(2)=zero
+      endif
+
+
+         
+*     
+*     Initialize the parameters.
 *
       kmin = 1
       kmax = 2
@@ -773,6 +803,7 @@ c         endif
 * if PISN occurs 
          if(kw.eq.15)then
             kstar(k)= kw
+            mass(k)= zero
             sgl = .true.
             goto 135
          endif
@@ -1381,9 +1412,11 @@ c            helper(2) = j2
          jp = MIN(jpmax,jp + 1)
          bpp(jp,1) = tphys
          bpp(jp,2) = mass(1)
-*         if(kstar(1).eq.15) bpp(jp,2) = mass0(1)
+*     if(kstar(1).eq.15) bpp(jp,2) = mass0(1)
+         if(kstar(1).eq.15) bpp(jp,2) = zero
          bpp(jp,3) = mass(2)
-*         if(kstar(2).eq.15) bpp(jp,3) = mass0(2)
+*     if(kstar(2).eq.15) bpp(jp,3) = mass0(2)
+         if(kstar(2).eq.15) bpp(jp,3) = zero
          bpp(jp,4) = float(kstar(1))
          bpp(jp,5) = float(kstar(2))
          bpp(jp,6) = sep
@@ -2088,6 +2121,7 @@ c         endif
 * if PISN occurs 
          if(kw.eq.15)then
             kstar(k) = kw
+            mass(k) = zero
             sgl = .true.
             goto 135
          endif
@@ -2343,9 +2377,9 @@ c            helper(2) = j2
          jp = MIN(jpmax,jp + 1)
          bpp(jp,1) = tphys
          bpp(jp,2) = mass(1)
-         if(kstar(1).eq.15) bpp(jp,2) = mass0(1)
+         if(kstar(1).eq.15) bpp(jp,2) = zero
          bpp(jp,3) = mass(2)
-         if(kstar(2).eq.15) bpp(jp,3) = mass0(2)
+         if(kstar(2).eq.15) bpp(jp,3) = zero
          bpp(jp,4) = float(kstar(1))
          bpp(jp,5) = float(kstar(2))
          bpp(jp,6) = sep
@@ -2393,9 +2427,11 @@ c            helper(2) = j2
             jp = MIN(jpmax,jp + 1)
             bpp(jp,1) = tphys
             bpp(jp,2) = mass(1)
-*            if(kstar(1).eq.15) bpp(jp,2) = mass0(1)
+*     if(kstar(1).eq.15) bpp(jp,2) = mass0(1)
+            if(kstar(1).eq.15) bpp(jp,2) = zero
             bpp(jp,3) = mass(2)
-*            if(kstar(2).eq.15) bpp(jp,3) = mass0(2)
+*     if(kstar(2).eq.15) bpp(jp,3) = mass0(2)
+            if(kstar(2).eq.15) bpp(jp,3) = zero
             bpp(jp,4) = float(kstar(1))
             bpp(jp,5) = float(kstar(2))
             bpp(jp,6) = zero
@@ -2448,13 +2484,13 @@ c            helper(2) = j2
          jp = MIN(jpmax,jp + 1)
          bpp(jp,1) = tphys
          bpp(jp,2) = mass(1)
-*         if(kstar(1).eq.15.and.bpp(jp-1,4).lt.15.0)then
-*            bpp(jp,2) = mass0(1)
-*         endif
+         if(kstar(1).eq.15.and.bpp(jp-1,4).lt.15.0)then
+            bpp(jp,2) = zero
+         endif
          bpp(jp,3) = mass(2)
-*         if(kstar(2).eq.15.and.bpp(jp-1,5).lt.15.0)then
-*            bpp(jp,3) = mass0(2)
-*         endif
+         if(kstar(2).eq.15.and.bpp(jp-1,5).lt.15.0)then
+            bpp(jp,3) = zero
+         endif
          bpp(jp,4) = float(kstar(1))
          bpp(jp,5) = float(kstar(2))
          bpp(jp,6) = zero
@@ -2470,6 +2506,14 @@ c            helper(2) = j2
 * Cases of accretion induced supernova or single star supernova.
 * No remnant is left in either case.
 *
+            bpp(jp,1) = tphys
+            bpp(jp,2) = zero
+            bpp(jp,3) = zero
+            bpp(jp,4) = float(kstar(1))
+            bpp(jp,5) = float(kstar(2))
+            bpp(jp,6) = zero
+            bpp(jp,7) = zero
+            bpp(jp,8) = zero
             bpp(jp,9) = ngtv2
 *            bpp(jp,10) = 11.0
             bpp(jp,10) = 13.0
@@ -2584,6 +2628,33 @@ c      bpp(jp+1,1) = -1.0
 *	
 c 150  continue
 *
+*
+      
+*     MM added following lines on 2021/09/27
+*     to zero masses and other dangerous quantities if stellar type is 15
+      if(kstar(1).eq.15)then
+         mass0(1)=zero
+         mass(1)=zero
+         rad(1)=1.0d-10
+         lumin(1)=1.0e-10
+         massc(1)=zero
+         radc(1)=1.0d-10
+         menv(1)=zero
+         renv(1)=1.0d-10
+         ospin(1)=zero
+      endif
+      if(kstar(2).eq.15)then
+         mass0(2)=zero
+         mass(2)=zero
+         rad(2)=1.0d-10
+         lumin(2)=1.0e-10
+         massc(2)=zero
+         radc(2)=1.0d-10
+         menv(2)=zero
+         renv(2)=1.0d-10
+         ospin(2)=zero
+      endif
+      
       RETURN
       END
 ***

--- a/bse-interface/mobse/hrdiag.f
+++ b/bse-interface/mobse/hrdiag.f
@@ -646,7 +646,13 @@ c            mcx = mcgbtf(aj,GB(8),GB,tscls(7),tscls(8),tscls(9))
 *
                   if(mrem.eq.0.0d0)then
                      kw = 15
-*
+*     MM added following 4 lines 2021/09/22
+                     aj = 0.d0
+                     mt = 0.d0
+                     lum = 1.0d-10
+                     r = 1.0d-10
+                     mc = 0.d0
+*     
 * We apply Timmes et al. 1996 for the neutrino-mass-loss, dmln, to both 
 * NS and BH if dmln < 0.5Msun, else dm = 0.5Msun
 *
@@ -659,6 +665,12 @@ c            mcx = mcgbtf(aj,GB(8),GB,tscls(7),tscls(8),tscls(9))
 * to prevent the formation of strange NS 
                         if(directcollapse.eq.1)then
                            kw = 15
+*     MM added following 4 lines 2021/09/22
+                           aj = 0.d0
+                           mt = 0.d0
+                           lum = 1.0d-10
+                           r = 1.0d-10
+                           mc = 0.d0
                         else
 * Zero-age Neutron star
                            kw = 13
@@ -860,6 +872,13 @@ c            mcx = mcgbtf(aj,GB(8),GB,tscls(7),tscls(8),tscls(9))
 *
                      if(mrem.eq.0.0d0)then
                         kw = 15
+*     MM added following 4 lines 2021/09/22
+                        aj = 0.d0
+                        mt = 0.d0
+                        lum = 1.0d-10
+                        r = 1.0d-10
+                        mc = 0.d0
+                        
 *
 * We apply Timmes et al. 1996 for the neutrino-mass-loss, dmln, to both 
 * NS and BH if dmln < 0.5Msun, else dm = 0.5Msun
@@ -873,6 +892,13 @@ c            mcx = mcgbtf(aj,GB(8),GB,tscls(7),tscls(8),tscls(9))
 * to prevent the formation of strange NS 
                            if(directcollapse.eq.1)then
                               kw = 15
+*     MM added following 4 lines 2021/09/22
+                              aj = 0.d0
+                              mt = 0.d0
+                              lum = 1.0d-10
+                              r = 1.0d-10
+                              mc = 0.d0
+                              
                            else
 * Zero-age Neutron star
                               kw = 13
@@ -1104,6 +1130,16 @@ c      if(mt.gt.150.0d0)then
 c        mt = mt0
 c      endif
 *
+      if(kw.eq.15)then
+         kw = 15
+*     MM added following 4 lines 2021/09/22
+         aj = 0.d0
+         mt = 0.d0
+         lum = 1.0d-10
+         r = 1.0d-10
+         mc = 0.d0
+      endif
+
       return
       end
 ***


### PR DESCRIPTION
We update three routines in bse-interface/mobse: 
- hrdiag.f
- evolv1.f
- evolv2.f
to fix for stellar mass after PISN.