### PR TITLE
Update bseemp

### DIFF
--- a/bse-interface/bseEmp/comenv.f
+++ b/bse-interface/bseEmp/comenv.f
@@ -1,1 +1,395 @@
-../bse/comenv.f
+***
+      SUBROUTINE COMENV(M01,M1,MC1,AJ1,JSPIN1,KW1,
+     &                  M02,M2,MC2,AJ2,JSPIN2,KW2,
+     &                  ZPARS,ECC,SEP,JORB,
+     &                  VKICK1,VKICK2,COEL)
+*
+* Common Envelope Evolution.
+*
+*     Author : C. A. Tout
+*     Date :   18th September 1996
+*
+*     Redone : J. R. Hurley
+*     Date :   7th July 1998
+*
+      IMPLICIT NONE
+*
+      INTEGER KW1,KW2,KW
+      INTEGER KTYPE(0:14,0:14)
+      COMMON /TYPES/ KTYPE
+      INTEGER ceflag,tflag,ifflag,nsflag,wdflag
+      COMMON /FLAGS/ ceflag,tflag,ifflag,nsflag,wdflag
+*
+      REAL*8 M01,M1,MC1,AJ1,JSPIN1,R1,L1,K21
+      REAL*8 M02,M2,MC2,AJ2,JSPIN2,R2,L2,K22,MC22
+      REAL*8 TSCLS1(20),TSCLS2(20),LUMS(10),GB(10),TM1,TM2,TN,ZPARS(20)
+      REAL*8 EBINDI,EBINDF,EORBI,EORBF,ECIRC,SEPF,SEPL,MF,XX
+      REAL*8 CONST,DELY,DERI,DELMF,MC3,FAGE1,FAGE2
+      REAL*8 ECC,SEP,JORB,TB,OORB,OSPIN1,OSPIN2,TWOPI
+      REAL*8 RC1,RC2,Q1,Q2,RL1,RL2,LAMB1,LAMB2
+      REAL*8 MENV,RENV,MENVD,RZAMS,VKICK1(4),VKICK2(4)
+      REAL*8 AURSUN,K3,ALPHA1,LAMBDA
+      real*8 FBFAC,FBTOT,MCO
+      integer ECS
+      PARAMETER (AURSUN = 214.95D0,K3 = 0.21D0) 
+****
+      REAL*8 ftzacc
+      PARAMETER (ftzacc=0.5D0)
+****
+      COMMON /VALUE2/ ALPHA1,LAMBDA
+      LOGICAL COEL
+      REAL*8 CELAMF,RL,RZAMSF
+      EXTERNAL CELAMF,RL,RZAMSF
+* Tanikawa's BH model (prevent HGCE)
+      logical nohgce
+      common /bseemp/ nohgce
+      logical coreenvornot
+*
+*
+* Common envelope evolution - entered only when KW1 = 2, 3, 4, 5, 6, 8 or 9.
+*
+* For simplicity energies are divided by -G.
+*
+      TWOPI = 2.D0*ACOS(-1.D0)
+      COEL = .FALSE.
+*
+* Obtain the core masses and radii.
+*
+      KW = KW1
+      CALL star(KW1,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
+      CALL hrdiag(M01,AJ1,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS,
+     &     R1,L1,KW1,MC1,RC1,MENV,RENV,K21,fbfac,fbtot,mco,ecs)
+      OSPIN1 = JSPIN1/(K21*R1*R1*(M1-MC1)+K3*RC1*RC1*MC1)
+      MENVD = MENV/(M1-MC1)
+      RZAMS = RZAMSF(M01)
+      LAMB1 = CELAMF(KW,M01,L1,R1,RZAMS,MENVD,LAMBDA)
+      KW = KW2
+      CALL star(KW2,M02,M2,TM2,TN,TSCLS2,LUMS,GB,ZPARS)
+      CALL hrdiag(M02,AJ2,M2,TM2,TN,TSCLS2,LUMS,GB,ZPARS,
+     &     R2,L2,KW2,MC2,RC2,MENV,RENV,K22,fbfac,fbtot,mco,ecs)
+      OSPIN2 = JSPIN2/(K22*R2*R2*(M2-MC2)+K3*RC2*RC2*MC2)
+*
+* Calculate the binding energy of the giant envelope (multiplied by lambda).
+*
+      EBINDI = M1*(M1-MC1)/(LAMB1*R1)
+*
+* If the secondary star is also giant-like add its envelopes's energy.
+*
+      EORBI = M1*M2/(2.D0*SEP)
+* Tanikawa's BH model (prevent HGCE)
+!      IF(KW2.GE.2.AND.KW2.LE.9.AND.KW2.NE.7)THEN
+      if(coreenvornot(nohgce,kw2))then
+*
+         MENVD = MENV/(M2-MC2)
+         RZAMS = RZAMSF(M02)
+         LAMB2 = CELAMF(KW,M02,L2,R2,RZAMS,MENVD,LAMBDA)
+         EBINDI = EBINDI + M2*(M2-MC2)/(LAMB2*R2)
+*
+* Calculate the initial orbital energy
+*
+         IF(CEFLAG.NE.3) EORBI = MC1*MC2/(2.D0*SEP)
+      ELSE
+         IF(CEFLAG.NE.3) EORBI = MC1*M2/(2.D0*SEP)
+      ENDIF
+*
+* Allow for an eccentric orbit.
+*
+      ECIRC = EORBI/(1.D0 - ECC*ECC)
+*
+* Calculate the final orbital energy without coalescence.
+*
+      EORBF = EORBI + EBINDI/ALPHA1
+*
+* If the secondary is on the main sequence see if it fills its Roche lobe.
+*
+* Tanikawa's BH model (prevent HGCE)
+!      IF(KW2.LE.1.OR.KW2.EQ.7)THEN
+      IF((.not. coreenvornot(nohgce,kw2)) .and. kw2.lt.10)THEN
+*
+         SEPF = MC1*M2/(2.D0*EORBF)
+* Check if any eccentricity remains in the orbit by first using 
+* energy to circularise the orbit before removing angular momentum. 
+* (note this should not be done in case of CE SN ... fix).  
+*
+         IF(EORBF.LT.ECIRC)THEN
+            ECC = SQRT(1.D0 - EORBF/ECIRC)
+         ELSE
+            ECC = 0.D0
+         ENDIF
+
+         Q1 = MC1/M2
+         Q2 = 1.D0/Q1
+         RL1 = RL(Q1)
+         RL2 = RL(Q2)
+         IF(RC1/RL1.GE.R2/RL2)THEN
+*
+* The helium core of a very massive star of type 4 may actually fill
+* its Roche lobe in a wider orbit with a very low-mass secondary.
+*
+            IF(RC1.GT.RL1*SEPF)THEN
+               COEL = .TRUE.
+               SEPL = RC1/RL1
+            ENDIF
+         ELSE
+            IF(R2.GT.RL2*SEPF)THEN
+               COEL = .TRUE.
+               SEPL = R2/RL2
+            ENDIF
+         ENDIF
+         IF(COEL)THEN
+*
+            KW = KTYPE(KW1,KW2) - 100
+            MC3 = MC1
+            IF(KW2.EQ.7.AND.KW.EQ.4) MC3 = MC3 + M2
+*
+* Coalescence - calculate final binding energy.
+*
+            EORBF = MAX(MC1*M2/(2.D0*SEPL),EORBI)
+            EBINDF = EBINDI - ALPHA1*(EORBF - EORBI)
+         ELSE
+*
+* Primary becomes a black hole, neutron star, white dwarf or helium star.
+*
+            MF = M1
+            M1 = MC1
+            CALL star(KW1,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
+            CALL hrdiag(M01,AJ1,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS,
+     &           R1,L1,KW1,MC1,RC1,MENV,RENV,K21,fbfac,fbtot,mco,ecs)
+            IF(KW1.GE.13)THEN
+               CALL kick(KW1,MF,M1,M2,ECC,SEPF,JORB,VKICK1,
+     &              fbfac,fbtot,mco,ecs)
+               IF(ECC.GT.1.D0) GOTO 30
+            ENDIF
+         ENDIF
+      ELSE
+*
+* Degenerate or giant secondary. Check if the least massive core fills its
+* Roche lobe.
+*
+         SEPF = MC1*MC2/(2.D0*EORBF)
+* Check if any eccentricity remains in the orbit by first using 
+* energy to circularise the orbit before removing angular momentum. 
+* (note this should not be done in case of CE SN ... fix).  
+*
+         IF(EORBF.LT.ECIRC)THEN
+            ECC = SQRT(1.D0 - EORBF/ECIRC)
+         ELSE
+            ECC = 0.D0
+         ENDIF
+         Q1 = MC1/MC2
+         Q2 = 1.D0/Q1
+         RL1 = RL(Q1)
+         RL2 = RL(Q2)
+         IF(RC1/RL1.GE.RC2/RL2)THEN
+            IF(RC1.GT.RL1*SEPF)THEN
+               COEL = .TRUE.
+               SEPL = RC1/RL1
+            ENDIF
+         ELSE
+            IF(RC2.GT.RL2*SEPF)THEN
+               COEL = .TRUE.
+               SEPL = RC2/RL2
+            ENDIF
+         ENDIF
+*
+         IF(COEL)THEN
+*
+* If the secondary was a neutron star or black hole the outcome
+* is an unstable Thorne-Zytkow object that leaves only the core.
+*
+            SEPF = 0.D0
+            IF(KW2.GE.13)THEN
+               MC1 = MC2
+*** Retain primary partially in case of a BH secondary
+               IF(KW2.EQ.14) MC1 = MC2 + (ftzacc*M1)
+               M1 = MC1
+               MC2 = 0.D0
+               M2 = 0.D0
+               KW1 = KW2
+               KW2 = 15
+               AJ1 = 0.D0
+*
+* The envelope mass is not required in this case.
+*
+               GOTO 30
+            ENDIF
+*
+            KW = KTYPE(KW1,KW2) - 100
+            MC3 = MC1 + MC2
+*
+* Calculate the final envelope binding energy.
+*
+            EORBF = MAX(MC1*MC2/(2.D0*SEPL),EORBI)
+            EBINDF = EBINDI - ALPHA1*(EORBF - EORBI)
+*
+* Check if we have the merging of two degenerate cores and if so
+* then see if the resulting core will survive or change form.
+*
+            IF(KW1.EQ.6.AND.(KW2.EQ.6.OR.KW2.GE.11))THEN
+               CALL dgcore(KW1,KW2,KW,MC1,MC2,MC3,EBINDF)
+            ENDIF
+            IF(KW1.LE.3.AND.M01.LE.ZPARS(2))THEN
+               IF((KW2.GE.2.AND.KW2.LE.3.AND.M02.LE.ZPARS(2)).OR.
+     &             KW2.EQ.10)THEN
+                  CALL dgcore(KW1,KW2,KW,MC1,MC2,MC3,EBINDF)
+                  IF(KW.GE.10)THEN
+                     KW1 = KW
+                     M1 = MC3
+                     MC1 = MC3
+                     IF(KW.LT.15) M01 = MC3
+                     AJ1 = 0.D0
+                     MC2 = 0.D0
+                     M2 = 0.D0
+                     KW2 = 15
+                     GOTO 30
+                  ENDIF
+               ENDIF
+            ENDIF
+*
+         ELSE
+*
+* The cores do not coalesce - assign the correct masses and ages.
+*
+            MF = M1
+            M1 = MC1
+            CALL star(KW1,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
+            CALL hrdiag(M01,AJ1,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS,
+     &           R1,L1,KW1,MC1,RC1,MENV,RENV,K21,fbfac,fbtot,mco,ecs)
+            IF(KW1.GE.13)THEN
+               CALL kick(KW1,MF,M1,M2,ECC,SEPF,JORB,VKICK1,
+     &              fbfac,fbtot,mco,ecs)
+               IF(ECC.GT.1.D0) GOTO 30
+            ENDIF
+            MF = M2
+            KW = KW2
+            M2 = MC2
+            CALL star(KW2,M02,M2,TM2,TN,TSCLS2,LUMS,GB,ZPARS)
+            CALL hrdiag(M02,AJ2,M2,TM2,TN,TSCLS2,LUMS,GB,ZPARS,
+     &           R2,L2,KW2,MC2,RC2,MENV,RENV,K22,fbfac,fbtot,mco,ecs)
+            IF(KW2.GE.13.AND.KW.LT.13)THEN
+               CALL kick(KW2,MF,M2,M1,ECC,SEPF,JORB,VKICK2,
+     &              fbfac,fbtot,mco,ecs)
+               IF(ECC.GT.1.D0) GOTO 30
+            ENDIF
+         ENDIF
+      ENDIF
+*
+      IF(COEL)THEN
+         MC22 = MC2
+         IF(KW.EQ.4.OR.KW.EQ.7)THEN
+* If making a helium burning star calculate the fractional age 
+* depending on the amount of helium that has burnt.
+            IF(KW1.LE.3)THEN
+               FAGE1 = 0.D0
+            ELSEIF(KW1.GE.6)THEN
+               FAGE1 = 1.D0
+            ELSE
+               FAGE1 = (AJ1 - TSCLS1(2))/(TSCLS1(13) - TSCLS1(2))
+            ENDIF
+            IF(KW2.LE.3.OR.KW2.EQ.10)THEN
+               FAGE2 = 0.D0
+            ELSEIF(KW2.EQ.7)THEN
+               FAGE2 = AJ2/TM2
+               MC22 = M2
+            ELSEIF(KW2.GE.6)THEN
+               FAGE2 = 1.D0
+            ELSE
+               FAGE2 = (AJ2 - TSCLS2(2))/(TSCLS2(13) - TSCLS2(2))
+            ENDIF
+         ENDIF
+      ENDIF
+*
+* Now calculate the final mass following coelescence.  This requires a
+* Newton-Raphson iteration.
+*
+      IF(COEL)THEN
+*
+* Calculate the orbital spin just before coalescence. 
+*
+         TB = (SEPL/AURSUN)*SQRT(SEPL/(AURSUN*(MC1+MC2)))
+         OORB = TWOPI/TB
+*
+         XX = 1.D0 + ZPARS(7)
+         IF(EBINDF.LE.0.D0)THEN
+            MF = MC3
+            GOTO 20
+         ELSE
+            CONST = ((M1+M2)**XX)*(M1-MC1+M2-MC22)*EBINDF/EBINDI
+         ENDIF
+*
+* Initial Guess.
+*
+         MF = MAX(MC1 + MC22,(M1 + M2)*(EBINDF/EBINDI)**(1.D0/XX))
+   10    DELY = (MF**XX)*(MF - MC1 - MC22) - CONST
+*        IF(ABS(DELY/MF**(1.D0+XX)).LE.1.0D-02) GOTO 20
+         IF(ABS(DELY/MF).LE.1.0D-03) GOTO 20
+         DERI = MF**ZPARS(7)*((1.D0+XX)*MF - XX*(MC1 + MC22))
+         DELMF = DELY/DERI
+         MF = MF - DELMF
+         GOTO 10
+*
+* Set the masses and separation.
+*
+   20    IF(MC22.EQ.0.D0) MF = MAX(MF,MC1+M2)
+         M2 = 0.D0
+         M1 = MF
+         KW2 = 15
+*
+* Combine the core masses.
+*
+         IF(KW.EQ.2)THEN
+            CALL star(KW,M1,M1,TM2,TN,TSCLS2,LUMS,GB,ZPARS)
+            IF(GB(9).GE.MC1)THEN
+               M01 = M1
+               AJ1 = TM2 + (TSCLS2(1) - TM2)*(AJ1-TM1)/(TSCLS1(1) - TM1)
+               CALL star(KW,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
+            ENDIF
+         ELSEIF(KW.EQ.7)THEN
+            M01 = M1
+            CALL star(KW,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
+            AJ1 = TM1*(FAGE1*MC1 + FAGE2*MC22)/(MC1 + MC22)
+         ELSEIF(KW.EQ.4.OR.MC2.GT.0.D0.OR.KW.NE.KW1)THEN
+            IF(KW.EQ.4) AJ1 = (FAGE1*MC1 + FAGE2*MC22)/(MC1 + MC22)
+            MC1 = MC1 + MC2
+            MC2 = 0.D0
+*
+* Obtain a new age for the giant.
+*
+            CALL gntage(MC1,M1,KW,ZPARS,M01,AJ1)
+            CALL star(KW,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
+         ENDIF
+         CALL hrdiag(M01,AJ1,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS,
+     &        R1,L1,KW,MC1,RC1,MENV,RENV,K21,fbfac,fbtot,mco,ecs)
+         JSPIN1 = OORB*(K21*R1*R1*(M1-MC1)+K3*RC1*RC1*MC1)
+         KW1 = KW
+         ECC = 0.D0
+      ELSE
+*
+* Check if any eccentricity remains in the orbit by first using 
+* energy to circularise the orbit before removing angular momentum. 
+* (note this should not be done in case of CE SN ... fix).  
+*
+         IF(EORBF.LT.ECIRC)THEN
+            ECC = SQRT(1.D0 - EORBF/ECIRC)
+         ELSE
+            ECC = 0.D0
+         ENDIF
+*
+* Set both cores in co-rotation with the orbit on exit of CE, 
+*
+         TB = (SEPF/AURSUN)*SQRT(SEPF/(AURSUN*(M1+M2)))
+         OORB = TWOPI/TB
+         JORB = M1*M2/(M1+M2)*SQRT(1.D0-ECC*ECC)*SEPF*SEPF*OORB
+*        JSPIN1 = OORB*(K21*R1*R1*(M1-MC1)+K3*RC1*RC1*MC1)
+*        JSPIN2 = OORB*(K22*R2*R2*(M2-MC2)+K3*RC2*RC2*MC2)
+*
+* or, leave the spins of the cores as they were on entry.
+* Tides will deal with any synchronization later.
+*
+         JSPIN1 = OSPIN1*(K21*R1*R1*(M1-MC1)+K3*RC1*RC1*MC1)
+         JSPIN2 = OSPIN2*(K22*R2*R2*(M2-MC2)+K3*RC2*RC2*MC2)
+      ENDIF
+   30 SEP = SEPF
+      RETURN
+      END
+***

--- a/bse-interface/bseEmp/const_bse.h
+++ b/bse-interface/bseEmp/const_bse.h
@@ -1,1 +1,33 @@
-../bse/const_bse.h
+*
+* const_bse.h
+*
+      INTEGER idum
+      COMMON /VALUE3/ idum
+      INTEGER idum2,iy,ir(32)
+      COMMON /RAND3/ idum2,iy,ir
+      INTEGER ktype(0:14,0:14)
+      COMMON /TYPES/ ktype
+      INTEGER ceflag,tflag,ifflag,nsflag,wdflag
+      COMMON /FLAGS/ ceflag,tflag,ifflag,nsflag,wdflag
+      INTEGER bhflag
+      INTEGER psflag,kmech,ecflag
+      COMMON /FLAGS2/ psflag,kmech,ecflag
+*
+      REAL*8 neta,bwind,hewind,mxns,alpha1,lambda
+      REAL*8 sigma,beta,xi,acc2,epsnov,eddfac,gamma
+      COMMON /VALUE1/ neta,bwind,hewind
+      COMMON /VALUE2/ alpha1,lambda
+      COMMON /VALUE4/ sigma,mxns,bhflag
+      COMMON /VALUE5/ beta,xi,acc2,epsnov,eddfac,gamma
+      REAL*8 pts1,pts2,pts3
+      COMMON /POINTS/ pts1,pts2,pts3
+*      REAL*8 dmmax,drmax
+*      COMMON /TSTEPC/ dmmax,drmax
+*      REAL scm(50000,14),spp(20,3)
+*      COMMON /SINGLE/ scm,spp
+*      REAL bcm(50000,34),bpp(80,10)
+*      COMMON /BINARY/ bcm,bpp
+      logical nohgce
+      integer krol(2)
+      common /bseemp/ nohgce,krol
+*

--- a/bse-interface/bseEmp/emptrack/cppinterface.h
+++ b/bse-interface/bseEmp/emptrack/cppinterface.h
@@ -52,6 +52,13 @@
       real(c_double) getWindMetallicity
       end function
 
+      function getCriticalMassMassive() 
+     &     bind(c, name='getCriticalMassMassive')
+      import
+      implicit none
+      real(c_double) getCriticalMassMassive
+      end function
+
       function askAllBlueOrNot(mt) bind(c, name='askAllBlueOrNot')
       import
       implicit none
@@ -76,6 +83,16 @@
       logical(c_bool) askBlueOrRed2
       end function
       
+      function askBlueOrRed3(lumpersun,radpersun,mt)
+     &     bind(c, name='askBlueOrRed3')
+      import
+      implicit none
+      real(c_double) lumpersun
+      real(c_double) radpersun
+      real(c_double) mt
+      logical(c_bool) askBlueOrRed3
+      end function
+      
       function askRadiativeOrNot(kw,aj,mass)
      & bind(c, name='askRadiativeOrNot')
       import
@@ -96,6 +113,17 @@
       logical(c_bool) askRadiativeOrNot2
       end function
 
+      function askRadiativeOrNot3(kw,lumpersun,radpersun,mt)
+     & bind(c, name='askRadiativeOrNot3')
+      import
+      implicit none
+      integer(c_int) kw
+      real(c_double) lumpersun
+      real(c_double) radpersun
+      real(c_double) mt
+      logical(c_bool) askRadiativeOrNot3
+      end function
+
       function getCriticalMassRatio(kw,aj,mass,massc) 
      & bind(c, name='getCriticalMassRatio')
       import
@@ -107,7 +135,8 @@
       real(c_double) getCriticalMassRatio
       end function
 
-      function getCriticalMassRatio2(kw,lumpersun,radpersun,mass,massc) 
+      function getCriticalMassRatio2(kw,lumpersun,radpersun,mass,massc,
+     &     preventCe) 
      & bind(c, name='getCriticalMassRatio2')
       import
       implicit none
@@ -116,7 +145,22 @@
       real(c_double) radpersun
       real(c_double) mass
       real(c_double) massc
+      integer(c_int) preventCe
       real(c_double) getCriticalMassRatio2
+      end function
+
+      function getCriticalMassRatio3(kw,lumpersun,radpersun,mass,massc,
+     &     preventCe) 
+     & bind(c, name='getCriticalMassRatio3')
+      import
+      implicit none
+      integer(c_int) kw
+      real(c_double) lumpersun
+      real(c_double) radpersun
+      real(c_double) mass
+      real(c_double) massc
+      integer(c_int) preventCe
+      real(c_double) getCriticalMassRatio3
       end function
 
       function askCommonEnvelopeOrNot(kw,aj,mass,q,qc,radx,radc) 
@@ -147,6 +191,22 @@
       real(c_double) radx
       real(c_double) radc
       logical(c_bool) askCommonEnvelopeOrNot2
+      end function
+      
+      function askCommonEnvelopeOrNot3(kw,lumpersun,radpersun,
+     &     mass,q,qc,radx,radc) 
+     &     bind(c, name='askCommonEnvelopeOrNot3')
+      import
+      implicit none
+      integer(c_int) kw
+      real(c_double) lumpersun
+      real(c_double) radpersun
+      real(c_double) mass
+      real(c_double) q
+      real(c_double) qc
+      real(c_double) radx
+      real(c_double) radc
+      logical(c_bool) askCommonEnvelopeOrNot3
       end function
       
       function getRatioOfTMSTimeToHeITime(mass)
@@ -349,6 +409,22 @@
       real(c_double) getCOCoreMassEndTime
       end function
 
+      function getTMSMassFromHeCoreMassHeITime(mc)
+     &     bind(c, name='getTMSMassFromHeCoreMassHeITime')
+      import
+      implicit none
+      real(c_double) mc
+      real(c_double) getTMSMassFromHeCoreMassHeITime
+      end function
+
+      function getTMSMassFromHeCoreMassBAGBTime(mc)
+     &     bind(c, name='getTMSMassFromHeCoreMassBAGBTime')
+      import
+      implicit none
+      real(c_double) mc
+      real(c_double) getTMSMassFromHeCoreMassBAGBTime
+      end function
+
       subroutine followAGBPhase(aj, mass, mt, lum, 
      &     r, rg, mcbagb, mc, mcx, mcmax)
      &     bind(c, name='followAGBPhase')
@@ -468,6 +544,20 @@
       implicit none
       real(c_double) mt
       real(c_double) getConvectiveCoreRadiusOfBluePhase
+      end function
+
+      subroutine setMetallicityInZUsingInBSE(zbse)
+     & bind(c, name='setMetallicityInZUsingInBSE')
+      import
+      implicit none
+      real(c_double) zbse
+      end subroutine
+
+      function getMetallicityInZUsingInBSE()
+     & bind(c, name='getMetallicityInZUsingInBSE')
+      import
+      implicit none
+      real(c_double) getMetallicityInZUsingInBSE
       end function
 
       end interface

--- a/bse-interface/bseEmp/emptrack/empfuncs.hpp
+++ b/bse-interface/bseEmp/emptrack/empfuncs.hpp
@@ -6,21 +6,29 @@ extern "C" {
     bool askAllBlueOrNot(F64 * mt);
     bool askInUseOrNot();
     bool askInScopeOfApplication(F64 * mass);
-    void setLowerLimitOfMass();
+    void setLowerLimitOfMass(F64 * mass);
     F64 getLowerLimitOfMass();
     F64 getUpperLimitOfMass();
     F64 getMetallicity();
     F64 getWindMetallicity();
+    F64 getCriticalMassMassive();
     bool askBlueOrRed(F64 * aj,
 		      F64 * mass);
     bool askBlueOrRed2(F64 * lumpersun,
 		       F64 * radpersun);
+    bool askBlueOrRed3(F64 * lumpersun,
+		       F64 * radpersun,
+		       F64 * mt);
     bool askRadiativeOrNot(S32 * kw,
 			   F64 * aj,
 			   F64 * mass);
     bool askRadiativeOrNot2(S32 * kw,
 			    F64 * lumpersun,
 			    F64 * radpersun);
+    bool askRadiativeOrNot3(S32 * kw,
+			    F64 * lumpersun,
+			    F64 * radpersun,
+			    F64 * mt);
     F64 getCriticalMassRatio(S32 * kw,
 			     F64 * aj,
 			     F64 * mass,
@@ -29,7 +37,14 @@ extern "C" {
 			      F64 * lumpersun,
 			      F64 * radpersun,
 			      F64 * mass,
-			      F64 * massc);
+			      F64 * massc,
+			      S32 * preventCe);
+    F64 getCriticalMassRatio3(S32 * kw,
+			      F64 * lumpersun,
+			      F64 * radpersun,
+			      F64 * mass,
+			      F64 * massc,
+			      S32 * preventCe);
     bool askCommonEnvelopeOrNot(S32 * kw,
 				F64 * aj,
 				F64 * mass,
@@ -38,6 +53,14 @@ extern "C" {
 				F64 * radx,
 				F64 * radc);
     bool askCommonEnvelopeOrNot2(S32 * kw,
+				 F64 * lumpersun,
+				 F64 * radpersun,
+				 F64 * mass,
+				 F64 * q,
+				 F64 * qc,
+				 F64 * radx,
+				 F64 * radc);
+    bool askCommonEnvelopeOrNot3(S32 * kw,
 				 F64 * lumpersun,
 				 F64 * radpersun,
 				 F64 * mass,
@@ -81,6 +104,9 @@ extern "C" {
     F64 getHeCoreMassBAGBTime(F64 * mass);
     F64 getCOCoreMassEndTime(F64 * mass);
 
+    F64 getTMSMassFromHeCoreMassHeITime(F64 * mc);
+    F64 getTMSMassFromHeCoreMassBAGBTime(F64 * mc);
+
     F64 getLuminosityMSPhaseMassive(F64 * mass,
 				    F64 * tau);
     F64 getLuminosityMSPhaseIntermediate(F64 * mass,
@@ -104,6 +130,9 @@ extern "C" {
 			    F64 * k2e);
 
     F64 getConvectiveCoreRadiusOfBluePhase(F64 * mt);
+
+    void setMetallicityInZUsingInBSE(F64 * zbse);
+    F64 getMetallicityInZUsingInBSE();
 
 #if defined(__cplusplus)
 }

--- a/bse-interface/bseEmp/emptrack/phasefuncs.cpp
+++ b/bse-interface/bseEmp/emptrack/phasefuncs.cpp
@@ -60,26 +60,26 @@ void followAGBPhase(F64 * aj,
     } else {
 	*mcx = *mcmax;
     }
-
     F64 tBAGB = getHeITime(mass) + getTimeIntervalOfCHeBPhase(mass);
     F64 tBlue = getEndTimeOfBluePhase(mass);
     F64 tFin  = getEndTime(mass);
-    if(askBlueOrRed(aj, mass) || askAllBlueOrNot(mt)) {
+
+    if(askBlueOrRed(aj, mass) || askAllBlueOrNot(mass)) {//    if(askBlueOrRed(aj, mass) || askAllBlueOrNot(mt)) { // (21/09/25)
 	F64 dt    = (tBlue - tBAGB != 0.) ? (*aj - tBAGB) : 0.;
 	F64 tau   = dt / (tBlue - tBAGB + TinyValue);
 	F64 tau3  = tau * tau * tau;
 	F64 lBAGB = getLuminosityBAGBTime(mass);
-	F64 rBAGB = getRadiusEndTimeOfBlueCHeBPhase(mt, mt, &lBAGB);
+	F64 rBAGB = getRadiusEndTimeOfBlueCHeBPhase(mass, mt, &lBAGB);//F64 rBAGB = getRadiusEndTimeOfBlueCHeBPhase(mt, mt, &lBAGB); //  (21/09/25)
 	F64 lBlue = getLuminosityEndTimeOfBluePhase(mass);
 	F64 ltemp = pow(10., lBlue);
-	F64 rBlue = (getEndTimeOfBluePhase(mt) == getEndTime(mt)) ?
-	    getRadiusEndTime(mt) : getRadiusRedPhase(mt, &ltemp);
+	F64 rBlue = (getEndTimeOfBluePhase(mass) == getEndTime(mass)) ? //F64 rBlue = (getEndTimeOfBluePhase(mt) == getEndTime(mt)) ? //  (21/09/25)
+	    getRadiusEndTime(mass) : getRadiusRedPhase(mt, &ltemp); //getRadiusEndTime(mt) : getRadiusRedPhase(mt, &ltemp); //  (21/09/25)
 	F64 lpower = lBAGB + tau3 * (lBlue - lBAGB);
 	F64 rpower = rBAGB + tau3 * (rBlue - rBAGB);
 	*lum = pow(10., lpower);
 	*r   = pow(10., rpower);
-// Tanikawa fixes this bug 21/09/20
-//      *rg  = getRadiusRedPhase(mt, lum);
+// A. Tanikawa fixes this bug 21/08/03
+//	*rg  = getRadiusRedPhase(mt, lum);
 	*rg  = pow(10., getRadiusRedPhase(mt, lum));
 //
     } else {

--- a/bse-interface/bseEmp/evolv1.f
+++ b/bse-interface/bseEmp/evolv1.f
@@ -329,7 +329,7 @@ c-------------------------------------------------------------c
          if(kw.ne.kwold) kwold = kw
          CALL deltat(kw,aj,tm,tn,tscls,dtm,dtr)
 * Tanikawa's prescription
-         if(askInUseOrNot() .and. askInScopeOfApplication(mt)) then
+         if(askInUseOrNot() .and. askInScopeOfApplication(mass)) then !         if(askInUseOrNot() .and. askInScopeOfApplication(mt)) then
             call calcTimestepAGBPhase(kw,aj,mass,tn,pts3,dtm,dtr)
          endif
 *

--- a/bse-interface/bseEmp/gntage.f
+++ b/bse-interface/bseEmp/gntage.f
@@ -86,34 +86,12 @@
 *
 * We fit a Helium core mass at the base of the AGB.
 *
-         m0 = mbagbf(mc)
-* A. Tanikawa adds here 21/09/24
+* Tanikawa's BH model (safe merger)
+!         m0 = mbagbf(mc)
          if(askInUseOrNot() .and. askInScopeOfApplication(m0)) then
-            mmax = getUpperLimitOfMass()
-            mmin = getLowerLimitOfMass()*0.5
-            fmid = getHeCoreMassBAGBTime(mmax) - mc
-            f    = getHeCoreMassBAGBTime(mmin) - mc
-            if(fmid*f.ge.0.d0)then
-               write(0,*)'Fatal error 1 in gntage.f.',
-     &              'Please contact A. Tankawa.',
-     &              'kw,mc,mt,aj=',kw,mc,mt,aj
-               stop
-            endif
-            m0 = mmin
-            dm = mmax-m0
-            do 200, j = 1,jmax*2
-               dm = 0.5d0*dm
-               mmid = m0 + dm
-               fmid = getHeCoreMassBAGBTime(mmid) - mc
-               if(fmid.lt.0.d0) m0 = mmid
-               if(ABS(dm).lt.macc.or.ABS(fmid).lt.1.d-3) exit
-               if(j.eq.jmax*2)then
-                  write(0,*)'Fatal error 2 in gntage.f.',
-     &                 'Please contact A. Tankawa.',
-     &                 'kw,mc,mt,aj=',kw,mc,mt,aj
-                  stop
-               endif
- 200        continue
+            m0 = getTMSMassFromHeCoreMassBAGBTime(mc)
+         else
+            m0 = mbagbf(mc)
          endif
 *
          if(m0.lt.tiny)then
@@ -155,38 +133,11 @@
             m0 = mmin
             goto 20
          endif
-* A. Tanikawa adds here 21/09/24
-         if(askInUseOrNot() .and. askInScopeOfApplication(mmax)) then
-            mmax = getUpperLimitOfMass()
-            mmin = getLowerLimitOfMass()*0.5
-            fmid = (1-aj)*getHeCoreMassHeITime(mmax) +
-     &           aj*getHeCoreMassBAGBTime(mmax) - mc
-            f    = (1-aj)*getHeCoreMassHeITime(mmin) + 
-     &           aj*getHeCoreMassBAGBTime(mmin) - mc
-            if(fmid*f.ge.0.d0)then
-               write(0,*)'Fatal error 1 in gntage.f.',
-     &              'Please contact A. Tankawa.',
-     &              'kw,mc,mt,aj=',kw,mc,mt,aj
-               !stop
-               kw = 3
-               goto 90
-            endif
-            m0 = mmin
-            dm = mmax-m0
-            do 100, j = 1,jmax*2
-               dm = 0.5d0*dm
-               mmid = m0 + dm
-               fmid = (1-aj)*getHeCoreMassHeITime(mmid) +
-     &              aj*getHeCoreMassBAGBTime(mmid) - mc
-               if(fmid.lt.0.d0) m0 = mmid
-               if(ABS(dm).lt.macc.or.ABS(fmid).lt.1.d-3) goto 20
-               if(j.eq.jmax*2)then
-                  write(0,*)'Fatal error 2 in gntage.f.',
-     &                 'Please contact A. Tankawa.',
-     &                 'kw,mc,mt,aj=',kw,mc,mt,aj
-                  stop
-               endif
- 100        continue
+* Tanikawa's BH model (safe merger)
+         if(askInUseOrNot() .and. askInScopeOfApplication(m0)) then
+            mmax = getTMSMassFromHeCoreMassHeITime(mc)
+            mmin = getTMSMassFromHeCoreMassBAGBTime(mc)
+            m0   = (mmax*mmin)**0.5
             goto 20
          endif
 *

--- a/bse-interface/bseEmp/hrdiag.f
+++ b/bse-interface/bseEmp/hrdiag.f
@@ -248,7 +248,7 @@
      &                 tau1,tau2,taumin)
                endif
 *
-               ry = ragbf(mt,lum,zpars(2))
+               ry = 10**(getRadiusRedPhase(mt,lum)) ! ry = ragbf(mt,lum,zpars(2))
                r  = MIN(r,ry)
             endif
 *
@@ -329,8 +329,8 @@
                r = rtms*(rx/rtms)**tau
 * Tanikawa's prescription
                if(askInUseOrNot()
-     &              .and. askInScopeOfApplication(mt)) then
-                  ry = ragbf(mt,lum,zpars(2))
+     &              .and. askInScopeOfApplication(mass)) then !     &              .and. askInScopeOfApplication(mt)) then
+                  ry = 10**(getRadiusRedPhase(mt,lum)) ! ry = ragbf(mt,lum,zpars(2))
                   r  = MIN(r,ry)
                endif
 *
@@ -426,13 +426,15 @@
             rmin = rminf(mass)
 * Tanikawa's prescription
 !            rg = rgbf(mt,lums(4))
-            if(askInUseOrNot() .and. askInScopeOfApplication(mt)) then
-               rg = ragbf(mt,lums(4),zpars(2))
+            if(askInUseOrNot() .and. askInScopeOfApplication(mass)) then !            if(askInUseOrNot() .and. askInScopeOfApplication(mt)) then
+               rg = 10**(getRadiusRedPhase(mt,lums(4))) ! rg = ragbf(mt,lums(4),zpars(2))
+               rx = 10**(getRadiusRedPhase(mt,lums(4))) 
             else
                rg = rgbf(mt,lums(4))
+               rx = ragbf(mt,lums(4),zpars(2))
             endif
 *
-            rx = ragbf(mt,lums(4),zpars(2))
+!            rx = ragbf(mt,lums(4),zpars(2))
             rmin = MIN(rmin, rx)
             if(mass.le.mlp) then
                texp = log(mass/mlp)/log(zpars(3)/mlp)
@@ -452,7 +454,7 @@
 * Tanikawa's prescription
             if(askInUseOrNot() .and. askInScopeOfApplication(mass)) then
                tloop = getEndTimeOfBluePhase(mass)
-               if(askAllBlueOrNot(mt)) then
+               if(askAllBlueOrNot(mass)) then !if(askAllBlueOrNot(mt)) then
                   tloop = tbagb
                endif
                tau2  = (tloop - tscls(2)) / tscls(3)
@@ -464,9 +466,14 @@
 * Tanikawa's prescription
 !               ry = ragbf(mt,ly,zpars(2))
                if(askInUseOrNot()
-     &              .and. askInScopeOfApplication(mt)) then
-                  ry = 10**(getRadiusEndTimeOfBlueCHeBPhase(mt,
+     &              .and. askInScopeOfApplication(mass)) then !     &              .and. askInScopeOfApplication(mt)) then
+                  ry = 10**(getRadiusEndTimeOfBlueCHeBPhase(mass, !                  ry = 10**(getRadiusEndTimeOfBlueCHeBPhase(mt,
      &                 mt, ly))
+                  If(.not. askBlueOrRed(tbagb,mass)) then
+                     !ry = sqrt(ry*ragbf(mt,ly,zpars(2))) ! keep continuity from type 4 to type 5 (21/09/25)
+                     ry = 10**((1.-tau)*log10(ry)
+     &                    +tau*getRadiusRedPhase(mt,ly)) !+tau*log10(ragbf(mt,ly,zpars(2)))) ! keep continuity from type 4 to type 5 (21/09/25)
+                  endif
                else
                   ry = ragbf(mt,ly,zpars(2))
                endif
@@ -482,18 +489,24 @@
                r = rmin*exp(abs(tau2)**3)
 * Tanikawa's prescription
                if(askInUseOrNot()
-     &              .and. askInScopeOfApplication(mt)) then
-                  ry = ragbf(mt,lum,zpars(2))
+     &              .and. askInScopeOfApplication(mass)) then !     &              .and. askInScopeOfApplication(mt)) then
+                  ry = 10**(getRadiusRedPhase(mt,lum)) ! ry = ragbf(mt,lum,zpars(2))
                   r  = MIN(r,ry)
                endif
                if(askInUseOrNot()
-     &              .and. askInScopeOfApplication(mt)) then
-                  ry = ragbf(mt,lums(7),zpars(2))
+     &              .and. askInScopeOfApplication(mass)) then !     &              .and. askInScopeOfApplication(mt)) then
+                  !ry = ragbf(mt,lums(7),zpars(2))
+                  ry = 10**(getRadiusRedPhase(mt,lums(7))) ! ry = ragbf(mt, lums(7),zpars(2)) ! keep continuity of ragbf between the original and mine (21/09/25)
                end if
 *
                rg = rg + tau*(ry - rg)
             else
-               r = ragbf(mt,lum,zpars(2))
+               if(askInUseOrNot()
+     &              .and. askInScopeOfApplication(mass)) then
+                  r = 10**(getRadiusRedPhase(mt,lum)) ! keep continuity of ragbf between the original and mine (21/09/25)
+               else
+                  r = ragbf(mt,lum,zpars(2))
+               endif
                rg = r
             end if
          else
@@ -553,10 +566,10 @@
 * is caught by the C core mass and they grow together.
 *
 * Tanikawa's prescription
-         if(askInUseOrNot() .and. askInScopeOfApplication(mt)) then
+         if(askInUseOrNot() .and. askInScopeOfApplication(mass)) then !         if(askInUseOrNot() .and. askInScopeOfApplication(mt)) then
             call followAGBPhase(aj, mass, mt, lum,
      &           r, rg, mcbagb, mc, mcx, mcmax)
-            ry = ragbf(mt,lum,zpars(2))
+            ry = 10**(getRadiusRedPhase(mt,lum)) ! ry = ragbf(mt,lum,zpars(2))
             r  = MIN(r,ry)
             if(mt.le.mc)then
                mcx = mcmax
@@ -872,6 +885,7 @@
             am = MAX(0.d0,0.4d0-0.22d0*LOG10(mt))
             r = rx*(1.d0+am*(tau-tau**6))
             rg = rx
+*
 * Star has no core mass and hence no memory of its past
 * which is why we subject mass and mt to mass loss for
 * this phase.

--- a/bse-interface/bseEmp/instar.f
+++ b/bse-interface/bseEmp/instar.f
@@ -1,1 +1,114 @@
-../bse/instar.f
+***
+      SUBROUTINE instar
+*
+*
+*       Initialization of collision matrix.
+*       ------------------------
+*
+      implicit none
+      integer i,j,ktype(0:14,0:14)
+      common /TYPES/ ktype
+*
+*       Initialize stellar collision matrix.
+*
+      ktype(0,0) = 1
+      do 10 , j = 1,6
+         ktype(0,j) = j
+         ktype(1,j) = j
+ 10   continue
+      ktype(0,7) = 4
+      ktype(1,7) = 4
+      do 15 , j = 8,12
+         if(j.ne.10)then
+            ktype(0,j) = 6
+         else
+            ktype(0,j) = 3
+         endif
+         ktype(1,j) = ktype(0,j)
+ 15   continue
+      ktype(2,2) = 3
+      do 20 , i = 3,14
+         ktype(i,i) = i
+ 20   continue
+      ktype(5,5) = 4
+      ktype(7,7) = 7
+      ktype(10,10) = 15
+* Tanikawa's DD model
+      ktype(11,11) = 12
+*
+      ktype(13,13) = 14
+      do 25 , i = 2,5
+         do 30 j = i+1,12
+            ktype(i,j) = 4
+ 30      continue
+ 25   continue
+      ktype(2,3) = 3
+      ktype(2,6) = 5
+* Tanikawa'BH model (prevent HGCE)
+      ktype(2,8) = 5
+      ktype(2,9) = 5
+*
+      ktype(2,10) = 3
+      ktype(2,11) = 5
+      ktype(2,12) = 5
+      ktype(3,6) = 5
+      ktype(3,10) = 3
+      ktype(3,11) = 5
+      ktype(3,12) = 5
+      ktype(6,7) = 4
+      ktype(6,8) = 6
+      ktype(6,9) = 6
+      ktype(6,10) = 5 
+      ktype(6,11) = 6
+      ktype(6,12) = 6
+      ktype(7,8) = 8
+      ktype(7,9) = 9
+      ktype(7,10) = 7
+      ktype(7,11) = 9
+      ktype(7,12) = 9
+      ktype(8,9) = 9
+      ktype(8,10) = 7
+      ktype(8,11) = 9
+      ktype(8,12) = 9
+      ktype(9,10) = 7
+      ktype(9,11) = 9
+      ktype(9,12) = 9
+      ktype(10,11) = 9
+      ktype(10,12) = 9
+      ktype(11,12) = 12
+      do 35 , i = 0,12
+         ktype(i,13) = 13
+         ktype(i,14) = 14
+ 35   continue
+      ktype(13,14) = 14
+*
+* Increase common-envelope cases by 100.
+      do 40 , i = 0,9
+         do 45 , j = i,14
+            if(i.le.1.or.i.eq.7)then
+               if(j.ge.2.and.j.le.9.and.j.ne.7)then
+                  ktype(i,j) = ktype(i,j) + 100
+               endif
+            else
+               ktype(i,j) = ktype(i,j) + 100
+            endif
+ 45      continue
+ 40   continue
+*
+*       Assign the remaining values by symmetry.
+      do 50 , i = 1,14
+         do 55 , j = 0,i-1
+            ktype(i,j) = ktype(j,i)
+ 55      continue
+ 50   continue
+*
+* Tanikawa'BH model (prevent HGCE)
+      do 60 , i =0,14
+         ktype(2,i) = ktype(2,i) - 100
+ 60   continue  
+      ktype(0,2) = ktype(0,2) - 100
+      ktype(1,2) = ktype(1,2) - 100
+*
+      return
+      end
+***

--- a/bse-interface/bseEmp/merge.f
+++ b/bse-interface/bseEmp/merge.f
@@ -1,1 +1,81 @@
-../bse/merge.f
+***
+      SUBROUTINE MERGE(kstar,mass0,mass,rad,massc,radc,menv,renv,ospin,
+     &     age,semi,ecc,vkick,zpars)
+      implicit none
+*
+*
+*     Hyperbolic merger
+*
+
+      INTEGER kstar(2),I1,I2,k
+      REAL*8  mass0(2),mass(2),rad(2),massc(2),radc(2),age(2)
+      REAL*8  semi,peri,ecc
+      REAL*8  TSCLS(20),LUMS(10),GB(10),zpars(20),TM,TN
+      REAL*8  LUM,Q,RL1,RL2
+      REAL*8  MENV(2),RENV(2),K2,ospin(2),jspin(2),jorb,vkick(8)
+      real*8 FBFAC,FBTOT,MCO,k3,EPS,TOL
+      integer ECS
+      PARAMETER (EPS = 1.0D-06, TOL = 1.0D-04, k3=0.21d0)
+      REAL*8 RL
+      EXTERNAL RL
+      LOGICAL coel
+* Tanikawa's BH model (prevent HGCE)
+      logical nohgce
+      integer krol(2)
+      common /bseemp/ nohgce,krol
+*
+
+* Tanikawa's BH model (prevent HGCE)
+      do k=1,2
+         krol(k) = k
+      enddo
+*
+
+      I1 = 1
+      I2 = 2
+*       Determine indices for primary & secondary star (donor & accretor).
+      Q = mass(I1)/mass(I2)
+      PERI = SEMI*(1-ecc)
+      RL1 = RL(Q)*ABS(PERI)
+*       Evaluate Roche radius for the second star.
+      Q = 1.0/Q
+      RL2 = RL(Q)*ABS(PERI)
+*
+*       Compare scaled Roche radii when choosing the primary.
+      IF (RAD(I1)/RL1.LT.RAD(I2)/RL2) THEN
+          I1 = 2
+          I2 = 1
+* Tanikawa's BH model (prevent HGCE)
+          krol(1) = i1
+          krol(2) = i2
+*
+          RL1 = RL2
+      END IF
+
+      IF(RAD(I1).GE.RL1.AND.((kstar(i1).ge.2.AND.kstar(i1).le.6).or.
+     &     (kstar(i1).ge.8.and.kstar(i1).le.9)) )THEN
+
+*     Convert Roche radius, radius and initial & current mass to SU.
+         
+         DO k=1,2 
+            CALL star(kstar(k),mass0(k),mass(k),tm,tn,tscls,
+     &           lums,GB,zpars)
+            CALL hrdiag(mass0(k),age(k),mass(k),tm,tn,tscls,lums,
+     &           GB,zpars,rad(k),lum,kstar(k),massc(k),radc(k),
+     &           menv(k),renv(k),k2,fbfac,fbtot,mco,ecs)
+            jspin(k) = ospin(k)*(k2*rad(k)*rad(k)*(mass(k)-massc(k))
+     &           +k3*radc(k)*radc(k)*massc(k))
+         END DO
+
+         CALL comenv(mass0(i1),mass(i1),massc(i1),age(i1),jspin(i1),
+     &        kstar(i1),mass0(i2),mass(i2),massc(i2),age(i2),
+     &        jspin(i2),kstar(i2),zpars,ecc,semi,jorb,
+     &        vkick(4*(i1-1)+1),vkick(4*(i2-1)+1),coel)
+         
+      ELSE
+         CALL MIX(mass0,mass,age,kstar,zpars)
+      END IF
+
+      RETURN
+
+      END

--- a/bse-interface/bseEmp/mix.f
+++ b/bse-interface/bseEmp/mix.f
@@ -1,1 +1,182 @@
-../bse/mix.f
+***
+      SUBROUTINE MIX(M0,M,AJ,KS,ZPARS)
+*
+*     Author : J. R. Hurley
+*     Date :   7th July 1998
+*
+*       Evolution parameters for mixed star.
+*       ------------------------------------
+*
+      implicit none
+*
+      INTEGER KS(2),I1,I2,K1,K2,KW,ICASE
+      INTEGER KTYPE(0:14,0:14)
+      COMMON /TYPES/ KTYPE
+      REAL*8 M0(2),M(2),AJ(2),ZPARS(20)
+      REAL*8 TSCLS(20),LUMS(10),GB(10),TMS1,TMS2,TMS3,TN
+      REAL*8 M01,M02,M03,M1,M2,M3,AGE1,AGE2,AGE3,MC3,MCH
+      PARAMETER(MCH=1.44D0)
+
+****
+      REAL*8 ftzacc
+      PARAMETER (ftzacc=0.5D0)
+****
+      REAL*8 sigma, mxns
+      INTEGER bhflag
+      COMMON /VALUE4/ sigma, mxns, bhflag
+* Tanikawa's BH model (prevent HGCE)
+      logical mixgiant
+      logical nohgce
+      integer krol(2)
+      common /bseemp/ nohgce,krol
+*
+*
+* Tanikawa's BH model (prevent HGCE)
+      icase = ktype(krol(1),krol(2))
+*
+*       Define global indices with body #I1 being most evolved.
+      IF(KS(1).GE.KS(2))THEN
+          I1 = 1
+          I2 = 2
+      ELSE
+          I1 = 2
+          I2 = 1
+      END IF
+*
+*       Specify case index for collision treatment.
+      K1 = KS(I1)
+      K2 = KS(I2)
+* Tanikawa's BH model (prevent HGCE)
+!      ICASE = KTYPE(K1,K2)
+*
+*     if(icase.gt.100) WRITE(66,*)' MIX ERROR ICASE>100 ',icase,k1,k2
+*
+*       Determine evolution time scales for first star.
+      M01 = M0(I1)
+      M1 = M(I1)
+      AGE1 = AJ(I1)
+      CALL star(K1,M01,M1,TMS1,TN,TSCLS,LUMS,GB,ZPARS)
+*
+*       Obtain time scales for second star.
+      M02 = M0(I2)
+      M2 = M(I2)
+      AGE2 = AJ(I2)
+      CALL star(K2,M02,M2,TMS2,TN,TSCLS,LUMS,GB,ZPARS)
+*
+*       Check for planetary systems - defined as HeWDs and low-mass WDs!
+      IF(K1.EQ.10.AND.M1.LT.0.05)THEN
+         ICASE = K2
+         IF(K2.LE.1)THEN
+            ICASE = 1
+            AGE1 = 0.D0
+         ENDIF
+      ELSEIF(K1.GE.11.AND.M1.LT.0.5.AND.ICASE.EQ.6)THEN
+         ICASE = 9
+      ENDIF
+      IF(K2.EQ.10.AND.M2.LT.0.05)THEN
+         ICASE = K1
+         IF(K1.LE.1)THEN
+            ICASE = 1
+            AGE2 = 0.D0
+         ENDIF
+      ENDIF
+*
+*       Specify total mass.
+      M3 = M1 + M2
+      M03 = M01 + M02
+      KW = ICASE
+      AGE3 = 0.d0
+*
+*       Restrict merged stars to masses less than 100 Msun. 
+*      IF(M3.GE.100.D0)THEN
+*         M3 = 99.D0
+*         M03 = MIN(M03,M3)
+*      ENDIF
+*
+*       Evaluate apparent age and other parameters.
+*
+      IF(ICASE.EQ.1)THEN
+*       Specify new age based on complete mixing.
+         IF(K1.EQ.7) KW = 7
+         CALL star(KW,M03,M3,TMS3,TN,TSCLS,LUMS,GB,ZPARS)
+         AGE3 = 0.1d0*TMS3*(AGE1*M1/TMS1 + AGE2*M2/TMS2)/M3
+* Tanikawa's BH model (prevent HGCE)
+      else if(nohgce .and. icase.eq.2)then
+         call star(kw,m03,m3,tms3,tn,tscls,lums,gb,zpars)
+         age3 = 0.1d0*tms3*(age1*m1/tms1+age2*m2/tms2)/m3
+*
+      ELSEIF(ICASE.EQ.3.OR.ICASE.EQ.6.OR.ICASE.EQ.9)THEN
+         MC3 = M1
+         CALL gntage(MC3,M3,KW,ZPARS,M03,AGE3)
+* Tanikawa's BH model (prevent HGCE)
+!      ELSEIF(ICASE.EQ.4)THEN
+      else if(mixgiant(nohgce,icase))then
+*
+         MC3 = M1
+         AGE3 = AGE1/TMS1
+         CALL gntage(MC3,M3,KW,ZPARS,M03,AGE3)
+      ELSEIF(ICASE.EQ.7)THEN
+         CALL star(KW,M03,M3,TMS3,TN,TSCLS,LUMS,GB,ZPARS)
+         AGE3 = TMS3*(AGE2*M2/TMS2)/M3
+      ELSEIF(ICASE.LE.12)THEN
+*       Ensure that a new WD has the initial mass set correctly.
+         M03 = M3
+         IF(ICASE.LT.12.AND.M3.GE.MCH)THEN
+            M3 = 0.D0
+            KW = 15
+         ENDIF
+      ELSEIF(ICASE.EQ.13.OR.ICASE.EQ.14)THEN
+*       Set unstable Thorne-Zytkow object with fast mass loss of envelope 
+*       unless the less evolved star is a WD, NS or BH. 
+         IF(K2.LT.10)THEN
+            M03 = M1
+            M3 = M1
+**** Condition to add fraction of mass to BH in case of
+**** main-seuqence BH collision         
+            IF((K1.EQ.14).AND.(K2.LE.1)) M3 = M1 + (ftzacc*M2)
+         ENDIF
+         IF(ICASE.EQ.13.AND.M3.GT.MXNS) KW = 14
+      ELSEIF(ICASE.EQ.15)THEN
+         M3 = 0.D0
+      ELSEIF(ICASE.GT.100)THEN
+*       Common envelope case which should only be used after COMENV.
+         KW = K1
+         AGE3 = AGE1
+         M3 = M1
+         M03 = M01
+      ELSE
+*       This should not be reached.
+        KW = 1
+        M03 = M3
+      ENDIF
+*
+* Put the result in *1.
+*
+      KS(1) = KW
+      KS(2) = 15
+      M(1) = M3
+      M(2) = 0.D0
+      M0(1) = M03
+      AJ(1) = AGE3
+*
+      RETURN
+      END
+***
+      logical function mixgiant(nohgce,icase)
+      implicit none
+      logical nohgce
+      integer icase
+      
+      mixgiant = .false.
+      if(nohgce)then
+         if(icase.eq.4 .or. icase.eq.5)then
+            mixgiant = .true.
+         endif
+      else
+         if(icase.eq.4)then
+            mixgiant = .true.
+         endif
+      endif
+
+      return
+      end

--- a/bse-interface/bse_interface.h
+++ b/bse-interface/bse_interface.h
@@ -488,7 +488,10 @@ static double EstimateGRTimescale(StarParameter& _star1, StarParameter& _star2, 
  */
 class BinaryEvent{
 public:
-    double record[20][9];
+    // Tanikawa's BH model
+    //double record[20][9];
+    double record[20][81];
+    //
 
     //! set up the initial parameter of binary event based on the present status of a binary
     void recordEvent(const StarParameter& _p1, const StarParameter& _p2, const double _semi, const double _ecc, const int _type, const int _index) {


### PR DESCRIPTION
Three major updated points.
1. Array size of record in class BainryEvent is enlarged because of a large number of events in bseemp.
2. Double white dwarf merger model is updated. The updated parts are highlighted by "Tanikawa's DD model". The model is based on Sato et al. (2015; 2016) and Kashyap et al. (2018). COWD-COWD remnants converted to ONeWD, NS, and BH depending on the total mass. Exceptionally, COWD-COWDs cause type Ia supernovae, and leave behind no remnants if the secondary COWD mass is larger than 0.8Msun.
3. Binary model is updated similarly to standalone BSEEMP used by Tanikawa et al. (2022, ApJ, 926, 83). The dynamical tide is close to Kinugawa et al. (2020), Hertzsprung gap common envelope is prohibitted like MOBSE, mass transfer stability criterion is close to Kinugawa et al. (2014) and non-CE model of Olejak et al. (2021, ApJL, 921, 2).