### PR TITLE
find.dt: nmpi defaults to 0 when -m is not set; no mpiexec when set -m 0 explicitly

### DIFF
--- a/tools/find_dt.sh
+++ b/tools/find_dt.sh
@@ -25,7 +25,7 @@ do
 	    echo '  -p: petar commander name (default: petar)';
 	    echo '  -s: base tree step size (default: auto)';
 #	    echo '  -b: binary number (default: 0)';
-	    echo '  -m: number of MPI processors (default: 1)';
+	    echo '  -m: number of MPI processors (default: 0, disable mpi)';
 	    echo '  -o: number of OpenMP processors (default: auto)';
 	    echo '  -i: format of snapshot: 0: BINARY; 1: ASCII (default: 1)';
 #	    echo '  -u: petar unit set (default: 0)';
@@ -61,7 +61,7 @@ fi
 #[ -z $opts ] || opts=''
 [ -z $pbin ] && pbin=petar
 [ -z $nomp ] || prefix='env OMP_NUM_THREADS='$nomp
-[ -z $nmpi ] || prefix=$prefix' mpiexec -n '$nmpi
+[ -n "$nmpi" ] && [ "$nmpi" -ne 0 ] && prefix=$prefix' mpiexec -n '$nmpi
 [ -z $sfmt ] && sfmt=1
 #[ -z $bnum ] || opts=$opts' -b '$bnum
 [ -z $prefix_flag ] || prefix=$run


### PR DESCRIPTION
Dear Long,

When I try PeTar on my local workstation, I was in this trouble. 

1. I run it on my single workstation, so I do `./configure --with-mpi=no`
2. When I type `petar.find.dt -h`, I see this line `-m: number of MPI processors (default: 1)`. And I think, ohh it defaults to 1, so I need to set `-m 0` because I did not configure MPI
3. And then petar.find.dt runs with `... mpiexec -n 0 petar ...`. Because I did not install mpich or openmpi on my workstation, it stops with error.

Then I go to the code and find this line in tools/find_dt.sh: `[ -z $nmpi ] || prefix=$prefix' mpiexec -n '$nmpi`, which actually does not set mpiexec when -m is not specified. I think this is a bit in conflict with the help message, which says it defaults to `-m 1`.

So I open this PR to suggest an update:
1. when -m 0 is explicitly set, do not apply mpiexec 
2. edit the help message to match the code: by default if -m is not set (mpi is disabled), so I say -m defaults to 0

Hope it helps PeTar users.

Best,
Kai Wu [吴开]